### PR TITLE
Test out Content Security Policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,7 @@ const contentSecurityPolicy = `
   img-src 'self' image.mux.com;
   media-src 'self' blob: image.mux.com;
   worker-src blob:;
-  connect-src: 'self' inferred.litix.io api-js.mixpanel.com mux.com;
+  connect-src 'self' inferred.litix.io api-js.mixpanel.com mux.com;
 `;
 
 const securityHeaders = [

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,35 @@
 /**
  * @type {import('next').NextConfig}
  * */
+
+const contentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self';
+  style-src 'self';
+  font-src 'self';
+  frame-src 'self';
+  child-src 'self';
+  img-src 'self';
+  media-src 'self';
+`;
+
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy-Report-Only",
+    value: contentSecurityPolicy.replace(/\s{2,}/g, " ").trim(),
+  },
+];
+
 module.exports = {
   poweredByHeader: false,
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        // Apply these headers to all routes in your application.
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -2,23 +2,30 @@
  * @type {import('next').NextConfig}
  * */
 
-const contentSecurityPolicy = `
-  default-src 'self';
-  script-src 'self';
-  style-src 'self' 'unsafe-inline';
-  font-src 'self';
-  frame-src 'self';
-  child-src 'self';
-  img-src 'self' image.mux.com;
-  media-src 'self' blob: image.mux.com;
-  worker-src blob:;
-  connect-src 'self' inferred.litix.io api-js.mixpanel.com mux.com;
-`;
+const contentSecurityPolicy = {
+  "default-src": ["'self'"],
+  "script-src": ["'self'"],
+  "style-src": ["'self'", "'unsafe-inline'"],
+  "font-src": ["'self'"],
+  "frame-src": ["'self'"],
+  "child-src": ["'self'"],
+  "img-src": ["'self'", "image.mux.com"],
+  "media-src": ["'self'", "blob:", "image.mux.com"],
+  "worker-src": ["blob:"],
+  "connect-src": ["'self'", "inferred.litix.io", "api-js.mixpanel.com", "*.mux.com"],
+};
+
+if (process.env.NODE_ENV === "development") {
+  // NextJS needs unsafe-eval for development as it uses source maps to help with debugging.
+  contentSecurityPolicy["script-src"].push("'unsafe-eval'");
+}
 
 const securityHeaders = [
   {
     key: "Content-Security-Policy-Report-Only",
-    value: contentSecurityPolicy.replace(/\s{2,}/g, " ").trim(),
+    value: Object.entries(contentSecurityPolicy)
+      .map(([k, v]) => k + " " + v.join(" "))
+      .join("; "),
   },
   {
     key: "X-Content-Type-Options",

--- a/next.config.js
+++ b/next.config.js
@@ -5,11 +5,11 @@
 const contentSecurityPolicy = `
   default-src 'self';
   script-src 'self';
-  style-src 'self';
+  style-src 'self' 'unsafe-inline';
   font-src 'self';
   frame-src 'self';
   child-src 'self';
-  img-src 'self';
+  img-src 'self' image.mux.com;
   media-src 'self';
 `;
 

--- a/next.config.js
+++ b/next.config.js
@@ -10,13 +10,27 @@ const contentSecurityPolicy = `
   frame-src 'self';
   child-src 'self';
   img-src 'self' image.mux.com;
-  media-src 'self';
+  media-src 'self' blob: image.mux.com;
+  worker-src blob:;
+  connect-src: 'self' inferred.litix.io api-js.mixpanel.com mux.com;
 `;
 
 const securityHeaders = [
   {
     key: "Content-Security-Policy-Report-Only",
     value: contentSecurityPolicy.replace(/\s{2,}/g, " ").trim(),
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "SAMEORIGIN",
+  },
+  {
+    key: "X-XSS-Protection",
+    value: "1; mode=block",
   },
 ];
 


### PR DESCRIPTION
- Add Content-Security-Policy-Report-Only with provisional CSP. This will NOT block anything yet; it will just warn.
- Add X-Frame-Options to avoid other people iframing us.
- Add X-XSS-Protection header to help avoid XSS attacks
- Add X-Content-Type-Options to avoid malicious re-interpretations of response content types.